### PR TITLE
feat(project): add uv script to allow simpler usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,10 @@ dev = ["ruff>=0.9.0", "basedpyright>=1.28", "pytest>=8.2.1,<9"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+
+[project.scripts]
+seedseeker = "seedseeker.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
With this the application can be run from the root directory using `uv run
seedseeker <args>`